### PR TITLE
[breaking] Misc. library fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,4 @@ node_modules: package.json
 .PHONY: build
 build: node_modules
 	./node_modules/.bin/babel src -d lib
+	./node_modules/.bin/flow-copy-source src lib

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -32,7 +32,7 @@ describe('middleware', () => {
             .get('/foo')
             .end(() => {
                 expect(beforeFn).toHaveBeenCalled();
-                expect(afterFn).toHaveBeenCalledWith({ foo: 'bar' });
+                expect(JSON.parse(afterFn.mock.calls[0][0])).toMatchObject({ foo: 'bar' });
                 done();
             });
     });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "precommit": "yarn run lint",
     "prepublishOnly": "make build",
     "test": "jest --coverage",
-    "lint": "eslint --fix src",
+    "lint": "eslint src",
     "flow": "flow check"
   },
   "devDependencies": {
@@ -19,6 +19,7 @@
     "babel-preset-flow": "^6.23.0",
     "eslint": "^4.12.0",
     "flow-bin": "^0.59.0",
+    "flow-copy-source": "^1.2.1",
     "husky": "^0.14.3",
     "jest": "^21.2.1",
     "supertest": "^3.0.0"
@@ -26,5 +27,7 @@
   "dependencies": {
     "express": "^4.16.2"
   },
-  "files": ["lib"]
+  "files": [
+    "lib"
+  ]
 }


### PR DESCRIPTION
This PR does the following

- distribute the flow types
- make responseBody always a string (motivation: flow typing requestDetails is easier, since the type is always the same. means less conditional logic inside tweens)