### PR TITLE
Add failing test showing that this library does not work with res.write/res.end

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -37,7 +37,7 @@ describe('middleware', () => {
             });
     });
 
-    it('should work with res.end', done => {
+    it('should work with res.send', done => {
         app.get('/foo', (req, res) => {
             res.send('foo');
         });
@@ -47,6 +47,38 @@ describe('middleware', () => {
             .end(() => {
                 expect(beforeFn).toHaveBeenCalled();
                 expect(afterFn).toHaveBeenCalledWith('foo');
+                done();
+            });
+    });
+
+    it('should work with res.send (json)', done => {
+        app.get('/foo', (req, res) => {
+            res.send({ foo: 'bar' });
+        });
+        
+        request(app)
+            .get('/foo')
+            .end(() => {
+                expect(beforeFn).toHaveBeenCalled();
+                expect(JSON.parse(afterFn.mock.calls[0][0])).toMatchObject({ foo: 'bar' });
+                done();
+            });
+    });
+
+    it.skip('should work with res.end', done => {
+        app.get('/foo', (req, res) => {
+            res.set('Content-Type', 'text/plain');
+            res.write('foo');
+            res.write('bar');
+            res.write('baz');
+            res.end();
+        });
+
+        request(app)
+            .get('/foo')
+            .end(() => {
+                expect(beforeFn).toHaveBeenCalled();
+                expect(afterFn).toHaveBeenCalledWith('foobarbaz');
                 done();
             });
     });

--- a/flow-typed/npm/express_v4.x.x.js
+++ b/flow-typed/npm/express_v4.x.x.js
@@ -1,7 +1,4 @@
-// flow-typed signature: f0e399a136d6e8dc8b1fbdc078e2850c
-// flow-typed version: ed397013d1/express_v4.x.x/flow_>=v0.32.x
-
-import type { Server } from 'http';
+import * as http from 'http';
 import type { Socket } from 'net';
 
 declare type express$RouterOptions = {
@@ -21,7 +18,7 @@ declare type express$RequestParams = {
 
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
-  body: any;
+  body: mixed;
   cookies: {[cookie: string]: string};
   connection: Socket;
   fresh: boolean;
@@ -161,20 +158,18 @@ declare class express$Router extends express$Route {
       id: string
     ) => mixed
   ): void;
-
-  // Can't use regular callable signature syntax due to https://github.com/facebook/flow/issues/3084
-  $call: (req: http$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction) => void;
+  (req: http$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
 }
 
 declare class express$Application extends express$Router mixins events$EventEmitter {
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
-  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
+  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): express$Application;
@@ -187,6 +182,8 @@ declare class express$Application extends express$Router mixins events$EventEmit
   set(name: string, value: mixed): mixed;
   render(name: string, optionsOrFunction: {[name: string]: mixed}, callback: express$RenderCallback): void;
   handle(req: http$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
+  // callable signature is not inherited
+  (req: http$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
 }
 
 declare module 'express' {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,16 @@
   "main": "lib/index.js",
   "author": "Mark Larah <mark@larah.me>",
   "license": "MIT",
-  "keywords": ["express", "pyramid", "tween", "middleware", "nodejs", "node"],
+  "keywords": [
+    "express",
+    "pyramid",
+    "tween",
+    "middleware",
+    "nodejs",
+    "node"
+  ],
   "homepage": "https://github.com/sharkcore/tweenz",
   "scripts": {
-    "precommit": "yarn run lint",
     "prepublishOnly": "make build",
     "test": "jest --coverage",
     "lint": "eslint src",
@@ -30,5 +36,12 @@
   "peerDependencies": {
     "express": "^4.x.x"
   },
-  "files": ["lib"]
+  "files": [
+    "lib"
+  ],
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn run lint"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "babel-preset-flow": "^6.23.0",
     "eslint": "^4.16.0",
     "express": "^4.16.2",
-    "flow-bin": "^0.65.0",
-    "flow-copy-source": "^1.2.1",
-    "husky": "^0.14.3",
-    "jest": "^22.0.0",
+    "flow-bin": "^0.89.0",
+    "flow-copy-source": "^2.0.2",
+    "husky": "^1.2.1",
+    "jest": "^23.6.0",
     "supertest": "^3.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
turns out this library doesn't work when [apps call](https://github.com/apollographql/apollo-server/blob/422609e62117ac371cd753312040a9a3add833a9/packages/apollo-server-express/src/expressApollo.ts#L47) `res.write` / `res.end` 😬 

I've added a failing test (with a `.skip`) that demonstrates this flaw.

```
╔═ markl@dev21-uswest1cdevc: ~/GitApps/tweenz git:(add_failing_test) ✗ virtualenv:(venv)
╚═ ♪ yarn test --no-watchman
yarn run v1.12.1
$ jest --coverage --no-watchman
 FAIL  __tests__/index.test.js
  middleware
    ✓ should work with res.json (38ms)
    ✓ should work with res.send (5ms)
    ✓ should work with res.send (json) (3ms)
    ✕ should work with res.end (11ms)

  ● middleware › should work with res.end

    expect(jest.fn()).toHaveBeenCalledWith(expected)

    Expected mock function to have been called with:
      "foobarbaz"
    as argument 1, but it was called with
      undefined.

    Difference:

      Comparing two different types of values. Expected string but received undefined.

      79 |             .end(() => {
      80 |                 expect(beforeFn).toHaveBeenCalled();
    > 81 |                 expect(afterFn).toHaveBeenCalledWith('foobarbaz');
         |                                 ^
      82 |                 done();
      83 |             });
      84 |     });

      at Test.toHaveBeenCalledWith (__tests__/index.test.js:81:33)
      at Test.Object.<anonymous>.Test.assert (node_modules/supertest/lib/test.js:181:6)
      at Server.localAssert (node_modules/supertest/lib/test.js:131:12)

----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |      100 |      100 |      100 |      100 |                   |
 index.js |      100 |      100 |      100 |      100 |                   |
----------|----------|----------|----------|----------|-------------------|
Test Suites: 1 failed, 1 total
Tests:       1 failed, 3 passed, 4 total
Snapshots:   0 total
Time:        1.415s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Let's fix this :P