### PR TITLE
Attempt to fix #21 (intercept res.write / res.end)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ A small library for writing [Express](https://expressjs.com/) middleware, inspir
 
 This library does the following:
 
-* Exposes the response body to the middleware (as part of `requestDetails`)
-* Provides a first class API to allow middleware to safely execute code after the request has finished
+-   Exposes the response body to the middleware (as part of `requestDetails`)
+-   Provides a first class API to allow middleware to safely execute code after the request has finished
+
+_**Please Note!** This middleware stores the whole response body in memory. If you are returning particularly large responses, you should be aware of this._
 
 ## Getting started
 
@@ -85,7 +87,7 @@ tweenz(tween [, tween ...])
 
 A tween is a callback, which will get executed with the following arguments
 
-- **`requestDetails`**
+-   **`requestDetails`**
 
     An object of the following type:
 
@@ -95,10 +97,10 @@ A tween is a callback, which will get executed with the following arguments
     }
     ```
 
-- **`req`**
+-   **`req`**
 
     [Express request object](http://expressjs.com/en/api.html#req)
 
-- **`res`**
+-   **`res`**
 
     [Express response object](http://expressjs.com/en/api.html#res)

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -65,20 +65,35 @@ describe('middleware', () => {
             });
     });
 
-    it.skip('should work with res.end', done => {
+    it('should work with just res.end', done => {
         app.get('/foo', (req, res) => {
             res.set('Content-Type', 'text/plain');
-            res.write('foo');
-            res.write('bar');
-            res.write('baz');
-            res.end();
+            res.end('foo');
         });
 
         request(app)
             .get('/foo')
             .end(() => {
                 expect(beforeFn).toHaveBeenCalled();
-                expect(afterFn).toHaveBeenCalledWith('foobarbaz');
+                expect(afterFn).toHaveBeenCalledWith('foo');
+                done();
+            });
+    });
+
+    it('should work with res.write + res.end', done => {
+        app.get('/foo', (req, res) => {
+            res.set('Content-Type', 'text/plain');
+            res.write('foo');
+            res.write('bar');
+            res.write('baz');
+            res.end('qux');
+        });
+
+        request(app)
+            .get('/foo')
+            .end(() => {
+                expect(beforeFn).toHaveBeenCalled();
+                expect(afterFn).toHaveBeenCalledWith('foobarbazqux');
                 done();
             });
     });

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "hooks": {
       "pre-commit": "yarn run lint"
     }
+  },
+  "dependencies": {
+    "bl": "^2.1.2"
   }
 }


### PR DESCRIPTION
in https://github.com/sharkcore/tweenz/pull/21, I added a failing test to show how this library doesn't work when [apps](https://github.com/apollographql/apollo-server/blob/422609e62117ac371cd753312040a9a3add833a9/packages/apollo-server-express/src/expressApollo.ts#L47) call `res.write` / `res.end`

This is a stab at fixing this, and generalizing the way in which we intercept data passed to the response object. Before, we were just monkey patching `res.json`, and it's tempting to just extend this behaviour to `res.write`. However, the problems here are:

- Having to deal with multiple ways to construct the `responseBody` (do we need to concat strings? buffers? just forward whatever was passed to res.json?)
- By extending out current logic and similarly monkey patching `res.write`, we have to remember what was passed, and combine a `chunks` array - at this point, we're approaching reimplementing pipes, badly. Also potentially leaky :(

So I thought since `res` (`http.ServerResponse`) is a Writable Stream, let's treat is as such and try and tap into the stream to get the response body.

This kind of works! Sort of!

So the failing test now works....but now I broke all the others :P 

when debugging, test output now looks like this:

```
  console.log __tests__/index.test.js:19
    responseBody is  {"foo":"bar"}{"foo":"bar"}

  console.log __tests__/index.test.js:19
    responseBody is  foofoo

  console.log __tests__/index.test.js:19
    responseBody is  {"foo":"bar"}{"foo":"bar"}
```

~~What's now happening is that [apparently `res.json()` does indeed call `res.write()` twice](https://stackoverflow.com/a/41490828/4396258)~~

I'll look for a way around this tomorrow but just wanted to give an early preview of what I'm up to.

Other thoughts:
- This is all in an attempt to not have to deal with polymorphism, worrying about types, strings vs buffers etc. This logic already exists and is battle tested in this library that we're now using - https://github.com/sindresorhus/get-stream/blob/master/buffer-stream.js. Let's add more tests and confirm that this handles different types as expected.