### PR TITLE
upgrade flow-bin and express flow defs

### DIFF
--- a/flow-typed/npm/express_v4.x.x.js
+++ b/flow-typed/npm/express_v4.x.x.js
@@ -1,5 +1,5 @@
-import * as http from 'http';
-import type { Socket } from 'net';
+// flow-typed signature: 7d9b176a1761d058112cd40520415468
+// flow-typed version: 2f514ea8dd/express_v4.x.x/flow_>=v0.94.x <=v0.103.x
 
 declare type express$RouterOptions = {
   caseSensitive?: boolean,
@@ -8,7 +8,7 @@ declare type express$RouterOptions = {
 };
 
 declare class express$RequestResponseBase {
-  app: express$Application;
+  app: express$Application<any, any>;
   get(field: string): string | void;
 }
 
@@ -16,11 +16,38 @@ declare type express$RequestParams = {
   [param: string]: string
 }
 
+/*
+  NOTE: Use caution when extending `express$Request` or `express$Response`. When
+  a request first hits the server, its `req` and `res` will not have any
+  additional properties, even if you explicitly type them with your custom
+  subclass. Subsequent middleware may assign these properties, but you must be
+  cognizant of this ordering. One way to handle this is marking all properties
+  as optional to force refinement every time a property is accessed. Therefore,
+  we advise that you always mark properties as _optional_ in `express$Request`
+  and `express$Response` subclasses.
+
+  You may decide not to do this, in which case the typings will be unsound and
+  the behavior will be similar to how arrays work in Flow. See here for more
+  information: https://flow.org/en/docs/types/arrays/#toc-array-access-is-unsafe
+
+  See #3578 and #3337 for additional discussion. If you have ideas on how to
+  improve these typings, please share them in #3578 or open a new issue.
+
+  **BAD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string;
+  }
+
+  **GOOD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string | void;
+  }
+*/
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
   body: mixed;
   cookies: {[cookie: string]: string};
-  connection: Socket;
+  connection: net$Socket;
   fresh: boolean;
   hostname: string;
   ip: string;
@@ -43,7 +70,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   acceptsEncodings(...encoding: Array<string>): string | false;
   acceptsLanguages(...lang: Array<string>): string | false;
   header(field: string): string | void;
-  is(type: string): boolean;
+  is(type: string): string | false;
   param(name: string, defaultValue?: string): string | void;
 }
 
@@ -100,79 +127,106 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 }
 
 declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
-declare type express$Middleware =
-  ((req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed) |
-  ((error: Error, req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed);
-declare interface express$RouteMethodType<T> {
-  (middleware: express$Middleware): T;
-  (...middleware: Array<express$Middleware>): T;
-  (path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): T;
+declare type express$Middleware<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> =
+  ((req: Req, res: Res, next: express$NextFunction) => mixed) |
+  ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
+
+declare interface express$RouteMethodType<
+  T,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> {
+  (middleware: express$Middleware<Req, Res>): T;
+  (...middleware: Array<express$Middleware<Req, Res>>): T;
+  (
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
+  ): T;
 }
-declare class express$Route {
-  all: express$RouteMethodType<this>;
-  get: express$RouteMethodType<this>;
-  post: express$RouteMethodType<this>;
-  put: express$RouteMethodType<this>;
-  head: express$RouteMethodType<this>;
-  delete: express$RouteMethodType<this>;
-  options: express$RouteMethodType<this>;
-  trace: express$RouteMethodType<this>;
-  copy: express$RouteMethodType<this>;
-  lock: express$RouteMethodType<this>;
-  mkcol: express$RouteMethodType<this>;
-  move: express$RouteMethodType<this>;
-  purge: express$RouteMethodType<this>;
-  propfind: express$RouteMethodType<this>;
-  proppatch: express$RouteMethodType<this>;
-  unlock: express$RouteMethodType<this>;
-  report: express$RouteMethodType<this>;
-  mkactivity: express$RouteMethodType<this>;
-  checkout: express$RouteMethodType<this>;
-  merge: express$RouteMethodType<this>;
+
+declare class express$Route<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> {
+  all: express$RouteMethodType<this, Req, Res>;
+  get: express$RouteMethodType<this, Req, Res>;
+  post: express$RouteMethodType<this, Req, Res>;
+  put: express$RouteMethodType<this, Req, Res>;
+  head: express$RouteMethodType<this, Req, Res>;
+  delete: express$RouteMethodType<this, Req, Res>;
+  options: express$RouteMethodType<this, Req, Res>;
+  trace: express$RouteMethodType<this, Req, Res>;
+  copy: express$RouteMethodType<this, Req, Res>;
+  lock: express$RouteMethodType<this, Req, Res>;
+  mkcol: express$RouteMethodType<this, Req, Res>;
+  move: express$RouteMethodType<this, Req, Res>;
+  purge: express$RouteMethodType<this, Req, Res>;
+  propfind: express$RouteMethodType<this, Req, Res>;
+  proppatch: express$RouteMethodType<this, Req, Res>;
+  unlock: express$RouteMethodType<this, Req, Res>;
+  report: express$RouteMethodType<this, Req, Res>;
+  mkactivity: express$RouteMethodType<this, Req, Res>;
+  checkout: express$RouteMethodType<this, Req, Res>;
+  merge: express$RouteMethodType<this, Req, Res>;
 
   // @TODO Missing 'm-search' but get flow illegal name error.
 
-  notify: express$RouteMethodType<this>;
-  subscribe: express$RouteMethodType<this>;
-  unsubscribe: express$RouteMethodType<this>;
-  patch: express$RouteMethodType<this>;
-  search: express$RouteMethodType<this>;
-  connect: express$RouteMethodType<this>;
+  notify: express$RouteMethodType<this, Req, Res>;
+  subscribe: express$RouteMethodType<this, Req, Res>;
+  unsubscribe: express$RouteMethodType<this, Req, Res>;
+  patch: express$RouteMethodType<this, Req, Res>;
+  search: express$RouteMethodType<this, Req, Res>;
+  connect: express$RouteMethodType<this, Req, Res>;
 }
 
-declare class express$Router extends express$Route {
+declare class express$Router<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> extends express$Route<Req, Res> {
   constructor(options?: express$RouterOptions): void;
-  route(path: string): express$Route;
-  static (options?: express$RouterOptions): express$Router;
-  use(middleware: express$Middleware): this;
-  use(...middleware: Array<express$Middleware>): this;
-  use(path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): this;
-  use(path: string, router: express$Router): this;
-  handle(req: http$IncomingMessage, res: http$ServerResponse, next: express$NextFunction): void;
+  route(path: string): express$Route<Req, Res>;
+  static <Req2: express$Request, Res2: express$Response>(
+    options?: express$RouterOptions,
+  ): express$Router<Req2, Res2>;
+  use(middleware: express$Middleware<Req, Res>): this;
+  use(...middleware: Array<express$Middleware<Req, Res>>): this;
+  use(
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
+  ): this;
+  use(path: string, router: express$Router<Req, Res>): this;
+  handle(req: http$IncomingMessage<>, res: http$ServerResponse, next: express$NextFunction): void;
   param(
     param: string,
     callback: (
-      req: $Subtype<express$Request>,
-      res: express$Response,
+      req: Req,
+      res: Res,
       next: express$NextFunction,
-      id: string
+      value: string,
+      paramName: string,
     ) => mixed
   ): void;
-  (req: http$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
+  (req: http$IncomingMessage<>, res: http$ServerResponse, next?: ?express$NextFunction): void;
 }
 
-declare class express$Application extends express$Router mixins events$EventEmitter {
+declare class express$Application<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> extends express$Router<Req, Res> mixins events$EventEmitter {
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
-  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
-  enable(name: string): express$Application;
+  enable(name: string): this;
   enabled(name: string): boolean;
   engine(name: string, callback: Function): void;
   /**
@@ -181,24 +235,33 @@ declare class express$Application extends express$Router mixins events$EventEmit
   //   get(name: string): mixed;
   set(name: string, value: mixed): mixed;
   render(name: string, optionsOrFunction: {[name: string]: mixed}, callback: express$RenderCallback): void;
-  handle(req: http$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
+  handle(req: http$IncomingMessage<>, res: http$ServerResponse, next?: ?express$NextFunction): void;
   // callable signature is not inherited
-  (req: http$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
+  (req: http$IncomingMessage<>, res: http$ServerResponse, next?: ?express$NextFunction): void;
 }
 
 declare module 'express' {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
-  declare export type Middleware = express$Middleware;
+  declare export type Middleware<
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
+  > = express$Middleware<Req, Res>;
   declare export type NextFunction = express$NextFunction;
   declare export type RequestParams = express$RequestParams;
   declare export type $Response = express$Response;
   declare export type $Request = express$Request;
-  declare export type $Application = express$Application;
+  declare export type $Application<
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
+  > = express$Application<Req, Res>;
 
   declare module.exports: {
-    (): express$Application, // If you try to call like a function, it will use this signature
-    static: (root: string, options?: Object) => express$Middleware, // `static` property on the function
-    Router: typeof express$Router, // `Router` property on the function
+    // If you try to call like a function, it will use this signature
+    <Req: express$Request, Res: express$Response>(): express$Application<Req, Res>,
+    // `static` property on the function
+    static: <Req: express$Request, Res: express$Response>(root: string, options?: Object) => express$Middleware<Req, Res>,
+    // `Router` property on the function
+    Router: typeof express$Router,
   };
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "main": "lib/index.js",
   "author": "Mark Larah <mark@larah.me>",
   "license": "MIT",
-  "keywords": ["express", "pyramid", "tween", "middleware", "nodejs", "node"],
+  "keywords": [
+    "express",
+    "pyramid",
+    "tween",
+    "middleware",
+    "nodejs",
+    "node"
+  ],
   "homepage": "https://github.com/sharkcore/tweenz",
   "scripts": {
     "prepublishOnly": "make build",
@@ -20,7 +27,7 @@
     "babel-preset-flow": "^6.23.0",
     "eslint": "^4.16.0",
     "express": "^4.16.2",
-    "flow-bin": "^0.89.0",
+    "flow-bin": "0.100.0",
     "flow-copy-source": "^2.0.2",
     "husky": "^1.2.1",
     "jest": "^23.6.0",
@@ -29,7 +36,9 @@
   "peerDependencies": {
     "express": "^4.x.x"
   },
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "husky": {
     "hooks": {
       "pre-commit": "yarn run lint"

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,9 @@ export type Tween = (
     $Response,
 ) => Promise<void>;
 
-export default function tweenz(...tweens: Array<Tween>): Middleware {
+export default function tweenz(
+    ...tweens: Array<Tween>
+): Middleware<$Request, $Response> {
     return (req: $Request, res: $Response, next: NextFunction) => {
         // we'll store all chunks passed to res.write/end in memory here
         const bufferList = new BufferList();


### PR DESCRIPTION
**Before**

```
markl on macbook in ~/apps/tweenz on git:master ✗ is 📦 v3.0.1-alpha.3
$ node_modules/.bin/flow status
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/index.js:17:58

Cannot use Middleware [1] without 0-2 type arguments.

     src/index.js
      14│     $Response,
      15│ ) => Promise<void>;
      16│
      17│ export default function tweenz(...tweens: Array<Tween>): Middleware {
      18│     return (req: $Request, res: $Response, next: NextFunction) => {
      19│         // we'll store all chunks passed to res.write/end in memory here
      20│         const bufferList = new BufferList();

     flow-typed/npm/express_v4.x.x.js
 [1] 246│   declare export type Middleware<
     247│     Req: express$Request = express$Request,
     248│     Res: express$Response = express$Response,
     249│   > = express$Middleware<Req, Res>;



Found 1 error
```

**After**

It works!

---

I'm going to bump this to v1.0.0 after this, I think we're fairly stable now :)